### PR TITLE
Credentials prompts not showing

### DIFF
--- a/unifi-webmail-autologin.user.js
+++ b/unifi-webmail-autologin.user.js
@@ -2,7 +2,7 @@
 // @id              unifi-webmail-autologin
 // @name            UniFi Webmail AutoLogin
 // @namespace       https://github.com/regi18
-// @version         1.0
+// @version         1.1
 // @author          regi18
 // @description     Automatically login to UniFi's webmail portal (the same login system is used to log into the Gsuite, i.e. Google, account)
 // @match           https://shibboleth2-mail.unifi.it/idp/Authn/UserPassword
@@ -12,6 +12,7 @@
 // @grant           GM_setValue
 // @grant           GM.deleteValue
 // @grant           GM_deleteValue
+// @run-at          document-idle
 // @updateURL       https://github.com/regi18/unifi-webmail-autologin
 // @downloadURL     https://github.com/regi18/unifi-webmail-autologin
 // ==/UserScript==
@@ -36,7 +37,7 @@ async function setCredentials(wasWrongCredentials = false) {
  */
 async function checkIfWrongCredentials() {
     // Check the correctness of the credentials based on the presence of an error message
-    wrongCredentialsBanner = document
+    let wrongCredentialsBanner = document
         .evaluate('//b[contains(., "Account non attivo o inesistente.")]', document, null, XPathResult.ANY_TYPE, null)
         .iterateNext();
 
@@ -56,7 +57,7 @@ async function checkIfWrongCredentials() {
 /**
  * Auto-logins on load
  */
-window.addEventListener('DOMContentLoaded', async () => {
+(async () => {
     // If credentials are not saved, ask the user to enter them
     if (!(await GM.getValue('username'))) await setCredentials(false);
     else await checkIfWrongCredentials();
@@ -67,4 +68,4 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     // Clicks the 'Login' button
     document.querySelector("input[type='submit'][value='Login']")?.click();
-});
+})();


### PR DESCRIPTION
Credentials prompts weren't working on new installations.

Instead of manually adding a listener for `DOMContentLoaded`, letting the extension do it automatically.